### PR TITLE
Fix reload model to reload encoder and decoder from the same file

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ python train.py
 ## main parameters
 --exp_name unsupMT_enfr                                       # experiment name
 --dump_path ./dumped/                                         # where to store the experiment
---reload_model 'mlm_enfr_1024.pth,mlm_enfr_1024.pth'          # model to reload for encoder,decoder
+--reload_model 'mlm_enfr_1024.pth'                            # model to reload
 
 ## data location / training objective
 --data_path ./data/processed/en-fr/                           # data location


### PR DESCRIPTION
Checkpoints are saved in a single file but the model reloading logic still assumed there were 2 (one for the encoder, one for the decoder).