### PR TITLE
fix fast-bpe install

### DIFF
--- a/install-tools.sh
+++ b/install-tools.sh
@@ -44,7 +44,7 @@ fi
 if [ ! -f "$FASTBPE" ]; then
   echo "Compiling fastBPE..."
   cd fastBPE
-  g++ -std=c++11 -pthread -O3 fast.cc -o fast
+  g++ -std=c++11 -pthread -O3 fastBPE/main.cc -IfastBPE -o fast
   cd ..
 fi
 


### PR DESCRIPTION
Running `install-tools.sh`, I encountered an error as below.
```
Compiling fastBPE...
g++: error: fast.cc: No such file or directory
g++: fatal error: no input files
compilation terminated.
````
I fixed compile command following [README](https://github.com/glample/fastBPE/blob/master/README.md) on glample's fastbpe.
