### PR TITLE
fix bpe sentences saving in jupyter notebook

### DIFF
--- a/generate-embeddings.ipynb
+++ b/generate-embeddings.ipynb
@@ -144,7 +144,7 @@
     "\n",
     "def to_bpe(sentences):\n",
     "    # write sentences to tmp file\n",
-    "    with open('/tmp/sentences', 'w') as fwrite:\n",
+    "    with open('/tmp/sentences.bpe', 'w') as fwrite:\n",
     "        for sent in sentences:\n",
     "            fwrite.write(sent + '\\n')\n",
     "    \n",


### PR DESCRIPTION
write was to `/tmp/sentences`, but reading from `/tmp/sentences.bpe`

this commit changes write to `/tmp/sentences.bpe`