### PR TITLE
Smal correction in example jupyter notebook

### DIFF
--- a/generate-embeddings.ipynb
+++ b/generate-embeddings.ipynb
@@ -144,7 +144,7 @@
     "\n",
     "def to_bpe(sentences):\n",
     "    # write sentences to tmp file\n",
-    "    with open('/tmp/sentences.bpe', 'w') as fwrite:\n",
+    "    with open('/tmp/sentences', 'w') as fwrite:\n",
     "        for sent in sentences:\n",
     "            fwrite.write(sent + '\\n')\n",
     "    \n",


### PR DESCRIPTION
Just a (breaking) small bug in the example notebook, the temporary file used should be `/tmp/sentences` and not `/tmp/sentences.bpe` (that is the output file)