### PR TITLE
fix typo (maybe) for ipython notebook demo

### DIFF
--- a/generate-embeddings.ipynb
+++ b/generate-embeddings.ipynb
@@ -144,7 +144,7 @@
     "\n",
     "def to_bpe(sentences):\n",
     "    # write sentences to tmp file\n",
-    "    with open('/tmp/sentences.bpe', 'w') as fwrite:\n",
+    "    with open('/tmp/sentences', 'w') as fwrite:\n",
     "        for sent in sentences:\n",
     "            fwrite.write(sent + '\\n')\n",
     "    \n",


### PR DESCRIPTION
## what
Fix a small bug for ipython notebook demo

## why
Apply bpe failed, source file not exist, maybe a typo

In the code several lines below, it consumes "/tmp/sentences" as source file
```bash
applybpe /tmp/sentences.bpe /tmp/sentences
```
But here it write sentences into "/tmp/sentences.bpe"
```python
with open('/tmp/sentences.bpe', 'w') as fwrite:
```

## change:
Write sentences into "/tmp/sentences":
```python
with open('/tmp/sentences', 'w') as fwrite:
```
